### PR TITLE
Remove .raw on buffers

### DIFF
--- a/hdfs3/core.py
+++ b/hdfs3/core.py
@@ -403,9 +403,9 @@ class HDFile(object):
                     break
                 if ret > 0:
                     if ret < bufsize:
-                        buffers.append(p.raw[:ret])
+                        buffers.append(p[:ret])
                     elif ret == bufsize:
-                        buffers.append(p.raw)
+                        buffers.append(p)
                     length -= ret
                 else:
                     raise IOError('Read Failed:', -ret)


### PR DESCRIPTION
b"".join() does the "right thing" without the additional copy (original buffer
is mutable memory, .raw is immutable bytes copy).

Seems to only be true in Py3!