### PR TITLE
Find libhdfs3 file through conda info

### DIFF
--- a/hdfs3/lib.py
+++ b/hdfs3/lib.py
@@ -6,10 +6,28 @@ Low-level interface to libhdfs3
 import sys
 import ctypes as ct
 import os
+import subprocess
 
 PY3 = sys.version_info.major > 2
-so_directory = '/opt/conda/lib'
+
+""" Find libhdfs3 file
+
+At the moment we assume the libhdfs3.so file has been installed by conda.
+We use subprocess to call conda-info and parse the output.
+
+This is brittle both to changes in conda info and in cases where users don't
+install libhdfs3 through conda.
+"""
+
+proc = subprocess.Popen(['conda', 'info'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+out, err = proc.communicate()
+conda_directory = next(line for line in out.split(b'\n')
+            if "default environment" in line.decode())
+conda_directory = conda_directory.decode().split(':')[-1].strip()
+so_directory = os.path.join(conda_directory, 'lib')
+
 _lib = ct.cdll.LoadLibrary(os.sep.join([so_directory, 'libhdfs3.so']))
+
 
 tSize = ct.c_int32
 tTime = ct.c_int64


### PR DESCRIPTION
At the moment we assume the libhdfs3.so file has been installed by conda.
We use subprocess to call conda-info and parse the output.

This is brittle both to changes in conda info and in cases where users don't
install libhdfs3 through conda.