### PR TITLE
add HDFileSystem.read_block method

### DIFF
--- a/hdfs3/tests/test_utils.py
+++ b/hdfs3/tests/test_utils.py
@@ -1,4 +1,4 @@
-from hdfs3.utils import seek_delimiter
+from hdfs3.utils import seek_delimiter, read_block
 from io import BytesIO
 
 
@@ -27,3 +27,26 @@ def test_seek_delimiter_endline():
     f.seek(5)
     seek_delimiter(f, b'\n', 5)
     assert f.tell() == 7
+
+
+def test_read_block():
+    fn = '/tmp/test/a'
+    delimiter = b'\n'
+    data = delimiter.join([b'123', b'456', b'789'])
+    f = BytesIO(data)
+
+    assert read_block(f, 1, 2) == b'23'
+    assert read_block(f, 0, 1, delimiter=b'\n') == b'123'
+    assert read_block(f, 0, 2, delimiter=b'\n') == b'123'
+    assert read_block(f, 0, 3, delimiter=b'\n') == b'123'
+    assert read_block(f, 0, 5, delimiter=b'\n') == b'123\n456'
+    assert read_block(f, 0, 8, delimiter=b'\n') == b'123\n456\n789'
+    assert read_block(f, 0, 100, delimiter=b'\n') == b'123\n456\n789'
+    assert read_block(f, 1, 1, delimiter=b'\n') == b''
+    assert read_block(f, 1, 5, delimiter=b'\n') == b'456'
+    assert read_block(f, 1, 8, delimiter=b'\n') == b'456\n789'
+
+    for ols in [[(0, 3), (3, 3), (6, 3), (9, 2)],
+                [(0, 4), (4, 4), (8, 4)]]:
+        out = [read_block(f, o, l, b'\n') for o, l in ols]
+        assert delimiter.join(filter(None, out)) == data

--- a/hdfs3/utils.py
+++ b/hdfs3/utils.py
@@ -29,3 +29,59 @@ def seek_delimiter(file, delimiter, blocksize):
         except ValueError:
             pass
         last = full[-len(delimiter):]
+
+
+def read_block(f, offset, length, delimiter=None):
+    """ Read a block of bytes from a file
+
+    Parameters
+    ----------
+    fn: string
+        Path to filename on HDFS
+    offset: int
+        Byte offset to start read
+    length: int
+        Number of bytes to read
+    delimiter: bytes (optional)
+        Ensure reading starts and stops at delimiter bytestring
+
+    If using the ``delimiter=`` keyword argument we ensure that the read
+    starts and stops at delimiter boundaries that follow the locations
+    ``offset`` and ``offset + length``.  If ``offset`` is zero then we
+    start at zero.  The bytestring returned will not include the
+    surrounding delimiter strings.
+
+    Examples
+    --------
+
+    >>> from io import BytesIO  # doctest: +SKIP
+    >>> f = BytesIO(b'Alice, 100\\nBob, 200\\nCharlie, 300')  # doctest: +SKIP
+    >>> read_block(f, 0, 13)  # doctest: +SKIP
+    b'Alice, 100\\nBo'
+
+    >>> read_block(f, 0, 13, delimiter=b'\\n')  # doctest: +SKIP
+    b'Alice, 100\\nBob, 200'
+
+    >>> read_block(f, 10, 10, delimiter=b'\\n')  # doctest: +SKIP
+    b'Bob, 200\\nCharlie, 300'
+    """
+    if delimiter:
+        f.seek(offset)
+        seek_delimiter(f, delimiter, 2**16)
+        start = f.tell()
+        length -= start - offset
+
+        f.seek(start + length)
+        seek_delimiter(f, delimiter, 2**16)
+        end = f.tell()
+        eof = not f.read(1)
+
+        offset = start
+        length = end - start
+
+        if length and not eof:
+            length -= len(delimiter)
+
+    f.seek(offset)
+    bytes = f.read(length)
+    return bytes


### PR DESCRIPTION
```python
    def read_block(self, fn, offset, length, delimiter=None):
        """ Read a block of bytes from a file

        Parameters
        ----------
        fn: string
            Path to filename on HDFS
        offset: int
            Byte offset to start read
        length: int
            Number of bytes to read
        delimiter: bytes (optional)
            Ensure reading starts and stops at delimiter bytestring

        If using the ``delimiter=`` keyword argument we ensure that the read
        starts and stops at delimiter boundaries that follow the locations
        ``offset`` and ``offset + length``.  If ``offset`` is zero then we
        start at zero.  The bytestring returned will not include the
        surrounding delimiter 
```

Examples
--------

```python
        >>> hdfs.read_block('/data/file.csv', 0, 13)  # doctest: +SKIP
        b'Alice, 100\nBob, '

        >>> hdfs.read_block('/data/file.csv', 0, 13, delimiter=b'\\n')  # doctest: +SKIP
        b'Alice, 100\nBob, 200'
```

cc @martindurant 