### PR TITLE
Remove encoding/decoding - no more text mode.

### DIFF
--- a/hdfs3/core.py
+++ b/hdfs3/core.py
@@ -552,7 +552,7 @@ class HDFile(object):
                 raise StopIteration
 
     def __iter__(self):
-        "Enables `for line in file:` usage"
+        """ Enables `for line in file:` usage """
         return self._genline()
 
     def readlines(self):
@@ -565,7 +565,7 @@ class HDFile(object):
         return out
 
     def seek(self, loc):
-        " Set file read position."
+        """ Set file read position."""
         info = self.info()
         loc = min(loc, info['size'])
         out = _lib.hdfsSeek(self._fs, self._handle, ctypes.c_int64(loc))

--- a/hdfs3/core.py
+++ b/hdfs3/core.py
@@ -272,6 +272,12 @@ class HDFileSystem(object):
         return out
 
     def glob(self, path):
+        """ Get list of paths mathing globstring (i.e., with "*"s).
+
+        If passed a directory, gets all contained files; if passed path
+        to a file, without any "*", returns one-element list containing that
+        filename.
+        """
         path = ensure_string(path)
         try:
             f = self.info(path)
@@ -517,8 +523,12 @@ class HDFile(object):
 
         Reads and caches chunksize bytes of data, and caches lines
         locally. Subsequent readline calls deplete those lines until
-        empty, when a new chunk will be read. Mixing readline with
-        read is not recommended.
+        empty, when a new chunk will be read. A read and readline are
+        not therefore generally pointing to the same location in the file;
+        `seek()` and `tell()` will give the true location in the file,
+        which will be one chunk in even after calling `readline` once.
+
+        Line iteration uses this method internally.
         """
         lineterminator = ensure_byte(lineterminator)
         lines = getattr(self, 'lines', [])

--- a/hdfs3/core.py
+++ b/hdfs3/core.py
@@ -273,8 +273,14 @@ class HDFileSystem(object):
 
     def glob(self, path):
         path = ensure_string(path)
-        if "*" not in path:
-            path = path + "*"
+        try:
+            f = self.info(path)
+            if f['kind'] == 'directory' and "*" not in path:
+                path = path + "*"
+            else:
+                return [f['name']]
+        except IOError:
+            pass
         if '/' in path[:path.index('*')]:
             ind = path[:path.index('*')].rindex('/')
             root = path[:ind+1]

--- a/hdfs3/core.py
+++ b/hdfs3/core.py
@@ -507,14 +507,14 @@ class HDFile(object):
         return b''.join(buffers)
 
     def readline(self, chunksize=2**16, lineterminator='\n'):
-        """ Read a buffered line, text mode. 
+        """ Return a line using buffered reading. 
 
         Reads and caches chunksize bytes of data, and caches lines
         locally. Subsequent readline calls deplete those lines until
         empty, when a new chunk will be read. Mixing readline with
         read is not recommended.
         """
-        lineterminator = ensure_string(lineterminator)
+        lineterminator = ensure_byte(lineterminator)
         lines = getattr(self, 'lines', [])
         if len(lines) < 1:
             buff = self.read(chunksize)

--- a/hdfs3/tests/test_hdfs3.py
+++ b/hdfs3/tests/test_hdfs3.py
@@ -326,9 +326,9 @@ def test_readline(hdfs, lineterminator):
         f.write(lineterminator.join([b'123', b'456', b'789']))
 
     with hdfs.open(a) as f:
-        assert f.readline(lineterminator=lineterminator) == '123'
-        assert f.readline(lineterminator=lineterminator) == '456'
-        assert f.readline(lineterminator=lineterminator) == '789'
+        assert f.readline(lineterminator=lineterminator) == b'123'
+        assert f.readline(lineterminator=lineterminator) == b'456'
+        assert f.readline(lineterminator=lineterminator) == b'789'
         with pytest.raises(EOFError):
             f.readline()
 

--- a/hdfs3/tests/test_hdfs3.py
+++ b/hdfs3/tests/test_hdfs3.py
@@ -149,15 +149,16 @@ def test_errors(hdfs):
 def test_glob(hdfs):
     hdfs.mkdir('/tmp/test/c/')
     hdfs.mkdir('/tmp/test/c/d/')
-    filenames = [b'a1', b'a2', b'a3', b'b1', b'c/x1', b'c/x2', b'c/d/x3']
+    filenames = [b'a', b'a1', b'a2', b'a3', b'b1', b'c/x1', b'c/x2', b'c/d/x3']
     filenames = [b'/tmp/test/' + s for s in filenames]
     for fn in filenames:
         hdfs.touch(fn)
 
     assert set(hdfs.glob('/tmp/test/a*')) == set([b'/tmp/test/' + a
-                                              for a in [b'a1', b'a2', b'a3']])
+               for a in [b'a', b'a1', b'a2', b'a3']])
     assert len(hdfs.glob('/tmp/test/c/')) == 4
     assert set(hdfs.glob('/tmp/test/')).issuperset(filenames)
+    assert set(hdfs.glob('/tmp/test/a')) == {b'/tmp/test/a'}
 
 
 def test_info(hdfs):


### PR DESCRIPTION
HDFS3 files are bytes on disc - here we are assuming that if the user wants to interpret them as strings, that's up to them.